### PR TITLE
Add missing error handling in main.js (acceptConsent)

### DIFF
--- a/agentic_security/static/main.js
+++ b/agentic_security/static/main.js
@@ -130,7 +130,12 @@ var app = new Vue({
         },
         acceptConsent() {
             this.showConsentModal = false; // Close the modal
-            localStorage.setItem('consentGiven', 'true'); // Save consent to local storage
+            
+            try {
+                localStorage.setItem('consentGiven', 'true'); // Save consent to local storage
+            } catch (e) {
+                this.showToast('Failed to save consent', 'error'); // Show error if saving fails
+            }
         },
 
         saveStateToLocalStorage() {


### PR DESCRIPTION
- [x] Wrapped the `localStorage.setItem` method in a try-catch block to handle potential errors.

- [x] In case of failure (e.g., storage full or disabled), an error toast is shown to the user, notifying them that the consent could not be saved.