### PR TITLE
error handling for httpx requests in MCP

### DIFF
--- a/agentic_security/mcp/main.py
+++ b/agentic_security/mcp/main.py
@@ -16,10 +16,19 @@ AGENTIC_SECURITY = "http://0.0.0.0:8718"
 async def verify_llm(spec: str) -> dict:
     """Verify an LLM model specification using the FastAPI server."""
     url = f"{AGENTIC_SECURITY}/verify"
-    async with httpx.AsyncClient() as client:
-        response = await client.post(url, json={"spec": spec})
-        return response.json()
-
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(url, json={"spec": spec})
+            response.raise_for_status()
+            return response.json()
+    except httpx.TimeoutException as e:
+        return {"error": f"Request timed out: {str(e)}"}
+    except httpx.HTTPStatusError as e:
+        return {"error": f"HTTP error {e.response.status_code}: {str(e)}"}
+    except httpx.RequestError as e:
+        return {"error": f"Request failed: {str(e)}"}
+    except Exception as e:
+       return {"error": f"Unexpected error: {str(e)}"}
 
 @mcp.tool()
 async def start_scan(
@@ -39,36 +48,75 @@ async def start_scan(
         "probe_datasets": [],
         "secrets": {},
     }
-    async with httpx.AsyncClient() as client:
-        response = await client.post(url, json=payload)
-        return response.json()
-
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+            return response.json()
+    except httpx.TimeoutException as e:
+        return {"error": f"Request timed out: {str(e)}"}
+    except httpx.HTTPStatusError as e:
+        return {"error": f"HTTP error {e.response.status_code}: {str(e)}"}
+    except httpx.RequestError as e:
+        return {"error": f"Request failed: {str(e)}"}
+    except Exception as e:
+        return {"error": f"Unexpected error: {str(e)}"}
 
 @mcp.tool()
 async def stop_scan() -> dict:
     """Stop an ongoing scan via the FastAPI server."""
     url = f"{AGENTIC_SECURITY}/stop"
-    async with httpx.AsyncClient() as client:
-        response = await client.post(url)
-        return response.json()
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(url)
+            response.raise_for_status()
+            return response.json()
+    except httpx.TimeoutException as e:
+        return {"error": f"Request timed out: {str(e)}"}
+    except httpx.HTTPStatusError as e:
+        return {"error": f"HTTP error {e.response.status_code}: {str(e)}"}
+    except httpx.RequestError as e:
+        return {"error": f"Request failed: {str(e)}"}
+    except Exception as e:
+        return {"error": f"Unexpected error: {str(e)}"}
 
 
 @mcp.tool()
 async def get_data_config() -> list:
     """Retrieve data configuration from the FastAPI server."""
     url = f"{AGENTIC_SECURITY}/v1/data-config"
-    async with httpx.AsyncClient() as client:
-        response = await client.get(url)
-        return response.json()
-
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.json()
+    except httpx.TimeoutException as e:
+        return {"error": f"Request timed out: {str(e)}"}
+    except httpx.HTTPStatusError as e:
+        return {"error": f"HTTP error {e.response.status_code}: {str(e)}"}
+    except httpx.RequestError as e:
+        return {"error": f"Request failed: {str(e)}"}
+    except Exception as e:
+        return {"error": f"Unexpected error: {str(e)}"}
 
 @mcp.tool()
 async def get_spec_templates() -> list:
     """Retrieve data configuration from the FastAPI server."""
     url = f"{AGENTIC_SECURITY}/v1/llm-specs"
-    async with httpx.AsyncClient() as client:
-        response = await client.get(url)
-        return response.json()
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.json()
+            
+    except httpx.TimeoutException as e:
+        return {"error": f"Request timed out: {str(e)}"}
+    except httpx.HTTPStatusError as e:
+        return {"error": f"HTTP error {e.response.status_code}: {str(e)}"}
+    except httpx.RequestError as e:
+        return {"error": f"Request failed: {str(e)}"}
+    except Exception as e:
+        return {"error": f"Unexpected error: {str(e)}"}
 
 
 # Run the MCP server


### PR DESCRIPTION
#196 

Implemented improved error handling for HTTPX requests to handle timeouts, connection errors, and invalid responses

Manually tested: Created a test file and verified all error handling cases, including timeouts, invalid URLs, and unreachable servers.

![image](https://github.com/user-attachments/assets/615428c3-3be6-4596-9b88-671efe6b25c7)
