### PR TITLE
Fixed the Dockerfile error of setuptools and wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ RUN poetry lock
 
 # Install dependencies
 RUN poetry export -f requirements.txt --without-hashes -o requirements.txt
+
+# Install wheel (required to build packages like fire)
+RUN pip install --upgrade pip setuptools wheel
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Runtime stage


### PR DESCRIPTION
## Description
I was building the project and when run docker build it broke in between, when checking found that installation of the setuptools and wheel command were missing and they are required for fire, so I fix the dockerfile.

## Error
![error](https://github.com/user-attachments/assets/88c40b39-ab7c-43ec-8131-eb44029ecf34)

After updating Dockerfile docker build completed successfully and project was build.  