### PR TITLE
feat: add full event log export for all scan events

### DIFF
--- a/agentic_security/probe_actor/fuzzer.py
+++ b/agentic_security/probe_actor/fuzzer.py
@@ -423,6 +423,7 @@ async def perform_single_shot_scan(
 
     yield ScanResult.status_msg("Scan completed.")
     fuzzer_state.export_failures("failures.csv")
+    fuzzer_state.export_full_log("full_scan_log.csv")
 
 
 async def perform_many_shot_scan(
@@ -558,6 +559,7 @@ async def perform_many_shot_scan(
 
     yield ScanResult.status_msg("Scan completed.")
     fuzzer_state.export_failures("failures.csv")
+    fuzzer_state.export_full_log("full_scan_log.csv")
 
 
 def scan_router(

--- a/agentic_security/probe_actor/state.py
+++ b/agentic_security/probe_actor/state.py
@@ -45,3 +45,45 @@ class FuzzerState:
             failure_data, columns=["module", "prompt", "status_code", "content"]
         )
         df.to_csv(filename, index=False)
+
+    def export_full_log(self, filename: str = "full_scan_log.csv"):
+        """Export a complete log of all events (errors, refusals, and successful outputs)"""
+        log_data = []
+
+        # Add errors
+        for module_name, prompt, status_code, error_msg in self.errors:
+            log_data.append({
+                "event_type": "error",
+                "module": module_name,
+                "prompt": prompt,
+                "status_code": status_code,
+                "content": error_msg,
+                "refused": None,
+            })
+
+        # Add refusals
+        for module_name, prompt, status_code, response_text in self.refusals:
+            log_data.append({
+                "event_type": "refusal",
+                "module": module_name,
+                "prompt": prompt,
+                "status_code": status_code,
+                "content": response_text,
+                "refused": True,
+            })
+
+        # Add all outputs (including successful ones)
+        for module_name, prompt, response_text, refused in self.outputs:
+            # Skip if already logged as refusal to avoid duplicates
+            if not refused:
+                log_data.append({
+                    "event_type": "success",
+                    "module": module_name,
+                    "prompt": prompt,
+                    "status_code": 200,
+                    "content": response_text,
+                    "refused": False,
+                })
+
+        df = pd.DataFrame(log_data)
+        df.to_csv(filename, index=False)


### PR DESCRIPTION
## Summary
- Adds `export_full_log()` method to `FuzzerState` class that exports a comprehensive log of all events
- Creates `full_scan_log.csv` with columns: `event_type`, `module`, `prompt`, `status_code`, `content`, `refused`
- Includes errors, refusals, and successful outputs (not just failures)

This addresses issue #100 by providing a complete audit trail of all fuzzer events for debugging and analysis purposes.

## Changes
- `agentic_security/probe_actor/state.py`: Added `export_full_log()` method
- `agentic_security/probe_actor/fuzzer.py`: Call `export_full_log()` after scan completes in both single-shot and many-shot scan functions

## Test plan
- [ ] Run a scan and verify `full_scan_log.csv` is created alongside `failures.csv`
- [ ] Verify CSV contains all event types (error, refusal, success)
- [ ] Verify columns are properly populated

Closes #100