### PR TITLE
fix: wildcard CORS + credentials spec violation, path-traversal guard on /icons proxy

### DIFF
--- a/agentic_security/middleware/cors.py
+++ b/agentic_security/middleware/cors.py
@@ -8,7 +8,6 @@ def setup_cors(app: FastAPI):
     app.add_middleware(
         CORSMiddleware,
         allow_origins=origins,
-        allow_credentials=True,
         allow_methods=["*"],  # Allows all methods
         allow_headers=["*"],  # Allows all headers
     )

--- a/agentic_security/routes/static.py
+++ b/agentic_security/routes/static.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import requests
@@ -12,6 +13,11 @@ from ..primitives import Settings
 router = APIRouter()
 STATIC_DIR = Path(__file__).parent.parent / "static"
 ICONS_DIR = STATIC_DIR / "icons"
+
+# Strict allowlist for icon filenames: lowercase/uppercase alphanumerics, dots,
+# underscores, and hyphens, must end in .png.  Rejects path separators,
+# percent-encoded characters, and non-PNG extensions before any FS/network I/O.
+ICON_NAME_RE = re.compile(r"[A-Za-z0-9._-]+\.png")
 
 # Configure templates with custom delimiters to avoid conflicts
 templates = Jinja2Templates(directory=str(STATIC_DIR))
@@ -96,8 +102,26 @@ async def favicon() -> FileResponse:
 
 @router.get("/icons/{icon_name}")
 async def serve_icon(icon_name: str) -> FileResponse:
-    """Serve an icon from the icons directory."""
-    icon_path = ICONS_DIR / icon_name
+    r"""Serve an icon from the icons directory.
+
+    ``icon_name`` is validated against a strict allowlist before any filesystem
+    or outbound-HTTP access:
+
+    * Must match ``^[A-Za-z0-9._-]+\.png$`` — rejects path separators,
+      percent-encoded characters, non-PNG extensions, and empty names.
+    * The resolved path must stay inside ``ICONS_DIR`` — defense-in-depth
+      against any future URL-handling change that could decode ``%2F``.
+
+    Mitigates CWE-22 (path traversal) on both the local write and the
+    upstream npmmirror fetch.
+    """
+    if not ICON_NAME_RE.fullmatch(icon_name):
+        raise HTTPException(status_code=400, detail="Invalid icon name")
+
+    icon_path = (ICONS_DIR / icon_name).resolve()
+    if not icon_path.is_relative_to(ICONS_DIR.resolve()):
+        raise HTTPException(status_code=400, detail="Invalid icon name")
+
     if not icon_path.exists():
         # Fetch the icon from the external URL and cache it
         url = f"https://registry.npmmirror.com/@lobehub/icons-static-png/latest/files/dark/{icon_name}"

--- a/tests/integration/routes/test_static_icon_validation.py
+++ b/tests/integration/routes/test_static_icon_validation.py
@@ -1,0 +1,109 @@
+"""Tests for the /icons/{icon_name} allowlist and path-containment guard (CWE-22)."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentic_security.routes.static import ICON_NAME_RE, router
+
+_app = FastAPI()
+_app.include_router(router)
+_client = TestClient(_app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# ICON_NAME_RE unit tests — no HTTP round-trip needed
+# ---------------------------------------------------------------------------
+
+
+class TestIconNameRegex:
+    """ICON_NAME_RE rejects all names that could cause path traversal or SSRF."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "openai.png",
+            "claude-3.png",
+            "gpt_4.png",
+            "Anthropic.png",
+            "my.icon.png",
+            "test-icon-123.png",
+            "A.png",
+        ],
+    )
+    def test_valid_names_match(self, name: str):
+        assert ICON_NAME_RE.fullmatch(name), f"Expected {name!r} to be accepted"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "../etc/passwd",  # classic path traversal
+            "../../secret.png",  # multi-level traversal
+            "foo%2Fbar.png",  # percent-encoded slash
+            "foo/bar.png",  # literal slash
+            "icon.PNG",  # uppercase extension (not in the dataset)
+            "icon.jpg",  # wrong extension
+            "icon.gif",  # wrong extension
+            ".png",  # empty stem
+            "",  # empty string
+            "icon.png.sh",  # double extension — shell script suffix
+            "\x00icon.png",  # null byte
+            "icon.png\n",  # trailing newline (defeats $-anchored match)
+        ],
+    )
+    def test_invalid_names_rejected(self, name: str):
+        assert not ICON_NAME_RE.fullmatch(name), f"Expected {name!r} to be rejected"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — HTTP-level validation via TestClient
+# ---------------------------------------------------------------------------
+
+
+class TestServeIconValidation:
+    """serve_icon returns 400 for names that fail the allowlist check."""
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "no-extension",
+            "icon.jpg",
+            "icon.PNG",
+            ".png",
+            "icon.png.sh",
+        ],
+    )
+    def test_invalid_name_returns_400(self, bad_name: str):
+        """Names that fail ICON_NAME_RE get a 400 before any FS/network I/O."""
+        response = _client.get(f"/icons/{bad_name}")
+        assert (
+            response.status_code == 400
+        ), f"Expected 400 for {bad_name!r}, got {response.status_code}"
+        assert response.json().get("detail") == "Invalid icon name"
+
+    def test_valid_name_does_not_return_400(self, tmp_path, mocker):
+        """A well-formed name passes validation; 404 is acceptable when the
+        upstream fetch also fails, but 400 must not be returned."""
+        mocker.patch("agentic_security.routes.static.ICONS_DIR", tmp_path)
+
+        # Stub the external HTTP call so the test is hermetic
+        mock_resp = mocker.MagicMock()
+        mock_resp.status_code = 404
+        mocker.patch(
+            "agentic_security.routes.static.requests.get", return_value=mock_resp
+        )
+
+        response = _client.get("/icons/openai.png")
+        assert (
+            response.status_code != 400
+        ), "A valid icon name should not be rejected by the allowlist check"
+
+    def test_valid_name_served_from_cache(self, tmp_path, mocker):
+        """When the icon file already exists locally it is served directly."""
+        mocker.patch("agentic_security.routes.static.ICONS_DIR", tmp_path)
+        icon_file = tmp_path / "openai.png"
+        icon_file.write_bytes(b"\x89PNG\r\n\x1a\n")  # minimal PNG magic bytes
+
+        response = _client.get("/icons/openai.png")
+        assert response.status_code == 200
+        assert response.headers.get("content-type", "").startswith("image/png")

--- a/tests/unit/test_cors_middleware.py
+++ b/tests/unit/test_cors_middleware.py
@@ -1,0 +1,94 @@
+"""Unit tests for CORS middleware configuration.
+
+Verifies that the wildcard-origins + allow_credentials=True spec violation
+(CORS spec §3.2, Fetch §4.7) has been removed.  Browsers silently strip
+credentials when the response carries Access-Control-Allow-Origin: * paired
+with Access-Control-Allow-Credentials: true, so the old config was both
+broken and misleading.
+"""
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+from agentic_security.middleware.cors import setup_cors
+
+
+def _get_cors_options(app: FastAPI) -> dict:
+    """Extract CORS middleware options from the app's middleware stack."""
+    for middleware in app.user_middleware:
+        if middleware.cls is CORSMiddleware:
+            return middleware.kwargs
+    return {}
+
+
+class TestCorsSetup:
+    """CORS middleware is configured correctly."""
+
+    def test_cors_middleware_is_registered(self):
+        """setup_cors adds CORSMiddleware to the app."""
+        app = FastAPI()
+        setup_cors(app)
+        cls_names = [m.cls.__name__ for m in app.user_middleware]
+        assert "CORSMiddleware" in cls_names
+
+    def test_wildcard_origins_without_credentials(self):
+        """allow_origins=['*'] must not be paired with allow_credentials=True.
+
+        The combination is forbidden by the CORS spec and causes browsers to
+        silently drop credentials on every cross-origin request.
+        """
+        app = FastAPI()
+        setup_cors(app)
+        opts = _get_cors_options(app)
+        allow_origins = opts.get("allow_origins", [])
+        allow_credentials = opts.get("allow_credentials", False)
+
+        if "*" in allow_origins or allow_origins == ["*"]:
+            assert not allow_credentials, (
+                "allow_origins=['*'] with allow_credentials=True is invalid per "
+                "the CORS spec — browsers reject it and credentials are silently dropped"
+            )
+
+    def test_cors_allows_cross_origin_requests(self):
+        """Cross-origin preflight requests return a 200 with CORS headers."""
+        app = FastAPI()
+
+        @app.get("/probe")
+        async def probe():
+            return {"ok": True}
+
+        setup_cors(app)
+        client = TestClient(app, raise_server_exceptions=True)
+
+        response = client.options(
+            "/probe",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.status_code == 200
+        assert "access-control-allow-origin" in response.headers
+
+    def test_cors_no_credentials_header_with_wildcard(self):
+        """With wildcard origins, the response must not include
+        Access-Control-Allow-Credentials: true."""
+        app = FastAPI()
+
+        @app.get("/probe")
+        async def probe():
+            return {"ok": True}
+
+        setup_cors(app)
+        client = TestClient(app)
+        response = client.get("/probe", headers={"Origin": "http://evil.example.com"})
+
+        acao = response.headers.get("access-control-allow-origin", "")
+        acac = response.headers.get("access-control-allow-credentials", "false")
+
+        if acao == "*":
+            assert acac.lower() != "true", (
+                "Wildcard ACAO + ACAC:true is a spec violation (RFC 6454 §7.2, "
+                "Fetch §4.7) and silently breaks credentialed cross-origin requests"
+            )


### PR DESCRIPTION
Closes #298

## Summary

Remove the `allow_credentials=True` / `allow_origins=["*"]` spec-invalid combo and add a strict allowlist + path-containment check on the `/icons/{icon_name}` endpoint before any filesystem write or outbound fetch.

## Problem / motivation

Two interlocking issues were filed in #298:

**1. CORS (middleware/cors.py:10)**

```python
origins = ["*"]
app.add_middleware(CORSMiddleware, allow_origins=origins, allow_credentials=True, ...)
```

`allow_origins=["*"]` combined with `allow_credentials=True` is explicitly forbidden by the CORS spec (Fetch §4.7, RFC 6454 §7.2). Browsers respond by silently stripping credentials on every cross-origin request, so the configuration neither works as intended nor provides any actual access control. The code _reads_ as "any origin may make authenticated requests" but _behaves_ as "any origin may make unauthenticated requests." Because the app uses Bearer tokens in request headers (not cookies), `allow_credentials` is unnecessary here.

**2. Path traversal / arbitrary-file-write surface (routes/static.py:100)**

```python
icon_path = ICONS_DIR / icon_name     # unsanitized path join
url = f"https://registry.npmmirror.com/.../dark/{icon_name}"  # unsanitized URL path
...
icon_path.write_bytes(response.content)   # writes attacker-controlled name
```

`icon_name` is taken directly from the URL path parameter and interpolated into both a filesystem path and an outbound URL with no validation. FastAPI's single-segment path parameters normally block literal `/`, but `%2F`-encoded slashes are handled inconsistently across Starlette versions and can decode to directory separators. The combined write surface represents CWE-22 (path traversal / arbitrary write) and a constrained SSRF-adjacent risk (controlled path component against a fixed host).

## Change

**`agentic_security/middleware/cors.py`**
- Removed `allow_credentials=True`. Wildcard origins remain; credentialed cross-origin access was not required and the setting was non-functional.

**`agentic_security/routes/static.py`**
- Added module-level `ICON_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+\.png$")`.
- `serve_icon()` now validates `icon_name` against `ICON_NAME_RE` before any I/O; returns HTTP 400 on mismatch.
- After path join, resolves the path and asserts `is_relative_to(ICONS_DIR.resolve())` as a defense-in-depth containment check; returns HTTP 400 if outside the icons directory. This layer defends against any future URL-handling change that could pass through encoded separators.

**`tests/unit/test_cors_middleware.py`** (new)
- Asserts `CORSMiddleware` is registered.
- Asserts wildcard origins are not paired with `allow_credentials=True`.
- Asserts OPTIONS preflight returns CORS headers.
- Asserts `Access-Control-Allow-Credentials: true` is absent when `ACAO: *`.

**`tests/integration/routes/test_static_icon_validation.py`** (new)
- `TestIconNameRegex`: parametrized unit tests for 7 valid and 11 invalid name patterns including path traversal, encoded slashes, wrong extensions, null bytes, and double extensions.
- `TestServeIconValidation`: integration tests via `TestClient` confirming 400 for invalid names, pass-through to 404 (not 400) for a valid-but-absent icon, and 200 for a cached icon (mocked FS).

## Security rationale

| Finding | CWE | Impact |
|---------|-----|--------|
| CORS wildcard + credentials | CWE-942 (Overly Permissive CORS) | Broken access control; credentials silently dropped — OWASP A01:2021 |
| Icon path traversal + write | CWE-22 (Path Traversal) | Arbitrary write within the server's FS permissions — OWASP A03:2021 |
| Icon URL path injection | CWE-73 (External Control of File Name or Path) | Controlled path against fixed upstream host |

The regex allowlist follows the principle of positive validation (allowlist over denylist), which is the OWASP-recommended approach for filename inputs. The `is_relative_to` check is a belt-and-suspenders layer that survives any future URL-decoding changes upstream.

## Testing / validation

```
python3 -m pytest tests/unit/test_cors_middleware.py \
                  tests/integration/routes/test_static_icon_validation.py \
                  tests/integration/routes/test_static.py -v
```

Result: **36 passed** (new CORS + icon-validation tests plus the existing `test_static.py` suite), no regressions. `icon_name` is matched with `re.fullmatch` against an anchorless allowlist so a trailing newline (`icon.png\n`) is also rejected.

Regex positive/negative coverage verified independently:

| Input | Expected | Result |
|-------|----------|--------|
| `openai.png` | MATCH | MATCH |
| `claude-3.png` | MATCH | MATCH |
| `../etc/passwd` | NO MATCH | NO MATCH |
| `../../secret.png` | NO MATCH | NO MATCH |
| `foo%2Fbar.png` | NO MATCH | NO MATCH |
| `icon.PNG` | NO MATCH | NO MATCH |
| `icon.png.sh` | NO MATCH | NO MATCH |
| `.png` (empty stem) | NO MATCH | NO MATCH |
