### PR TITLE
Add OrcaRouter as a built-in scan target

### DIFF
--- a/agentic_security/routes/_specs.py
+++ b/agentic_security/routes/_specs.py
@@ -176,6 +176,20 @@ Content-Type: application/json
   "presence_penalty": 0
 }
 """,
+    """POST https://api.orcarouter.ai/v1/chat/completions
+Authorization: Bearer $ORCAROUTER_API_KEY
+Content-Type: application/json
+
+{
+  "model": "openai/gpt-5.5",
+  "messages": [{"role": "user", "content": "<<PROMPT>>"}],
+  "temperature": 0.7,
+  "max_tokens": 150,
+  "top_p": 0.9,
+  "frequency_penalty": 0,
+  "presence_penalty": 0
+}
+""",
 ]
 
 
@@ -357,6 +371,20 @@ Content-Type: application/json
   "presence_penalty": 0
 }
 """,
+    """POST https://api.orcarouter.ai/v1/chat/completions
+Authorization: Bearer $ORCAROUTER_API_KEY
+Content-Type: application/json
+
+{
+  "model": "openai/gpt-5.5",
+  "messages": [{"role": "user", "content": "<<PROMPT>>"}],
+  "temperature": 0.7,
+  "max_tokens": 150,
+  "top_p": 0.9,
+  "frequency_penalty": 0,
+  "presence_penalty": 0
+}
+""",
 ]
 
 
@@ -392,6 +420,7 @@ LLM_CONFIGS = [
     {"name": "Azure OpenAI", "prompts": 40000, "logo": "/icons/azureai.png"},
     {"name": "assemblyai", "prompts": 40000, "logo": "/icons/myshell.png"},
     {"name": "OpenRouter.ai", "prompts": 40000, "logo": "/icons/openrouter.png"},
+    {"name": "OrcaRouter", "prompts": 40000, "logo": "/icons/myshell.png"},
 ]
 
 LLM_SPECS = [dict(spec=spec, **d) for spec, d in zip(_SPECS, LLM_CONFIGS)]

--- a/agentic_security/static/base.js
+++ b/agentic_security/static/base.js
@@ -187,6 +187,21 @@ Content-Type: application/json
 }
 `,
 
+  `POST https://api.orcarouter.ai/v1/chat/completions
+Authorization: Bearer $ORCAROUTER_API_KEY
+Content-Type: application/json
+
+{
+  "model": "openai/gpt-5.5",
+  "messages": [{"role": "user", "content": "<<PROMPT>>"}],
+  "temperature": 0.7,
+  "max_tokens": 150,
+  "top_p": 0.9,
+  "frequency_penalty": 0,
+  "presence_penalty": 0
+}
+`,
+
 ]
 
 let fallbackIcon = '/icons/myshell.png';
@@ -206,6 +221,7 @@ let LLM_CONFIGS = [
   { name: 'Azure OpenAI', prompts: 40000, logo: '/icons/azureai.png' },
   { name: 'assemblyai', prompts: 40000, logo: fallbackIcon },
   { name: 'OpenRouter.ai', prompts: 40000, logo: '/icons/openrouter.png' },
+  { name: 'OrcaRouter', prompts: 40000, logo: fallbackIcon },
 
 ];
 function has_image(spec) {


### PR DESCRIPTION
## Add OrcaRouter as a built-in scan target

Adds [OrcaRouter](https://www.orcarouter.ai) to the LLM endpoint dropdown, mirroring the existing OpenRouter entry.

**What's included:**

- `agentic_security/routes/_specs.py` — new OrcaRouter API spec template (`POST https://api.orcarouter.ai/v1/chat/completions`, OpenAI-compatible, `$ORCAROUTER_API_KEY`) in both spec lists, plus a matching `OrcaRouter` entry in `LLM_CONFIGS`.
- `agentic_security/static/base.js` — the same OrcaRouter spec template and `LLM_CONFIGS` entry for the frontend dropdown, kept index-aligned with the spec list.

Both the Python (`_SPECS` + `LLM_CONFIGS` → `/v1/llm-specs`) and frontend (`LLM_SPECS` + `LLM_CONFIGS`) lists stay aligned at 15 entries each, with OrcaRouter appearing alongside OpenRouter.ai. OrcaRouter exposes an OpenAI-compatible `/v1` chat/completions API, so the spec template uses the same `messages` format as the existing OpenAI/DeepSeek/Together entries and works with the scanner out of the box.

I'm an engineer on the OrcaRouter team. OrcaRouter is a secure, privacy-focused LLM gateway that unifies OpenAI-compatible model access behind a single API.
