### PR TITLE
fix(circuit-breaker): reopen on failure during half-open probation

### DIFF
--- a/agentic_security/executor/circuit_breaker.py
+++ b/agentic_security/executor/circuit_breaker.py
@@ -51,6 +51,15 @@ class CircuitBreaker:
 
     def record_failure(self):
         """Record a failed request."""
+        if self.state == "half_open":
+            # A single failure during probation trips the circuit back open
+            # with fresh counters, so the failure is not diluted by the
+            # minimum-sample gate or forgiven by later successes.
+            self.state = "open"
+            self.last_failure_time = time.monotonic()
+            self.failures = 0
+            self.successes = 0
+            return
         self.failures += 1
         self.last_failure_time = time.monotonic()
 

--- a/tests/unit/executor/test_circuit_breaker.py
+++ b/tests/unit/executor/test_circuit_breaker.py
@@ -119,6 +119,51 @@ class TestCircuitBreaker:
         # Should transition to closed
         assert breaker.state == "closed"
 
+    def test_half_open_failure_reopens_circuit(self):
+        """Test that a failure during half-open probation reopens the circuit."""
+        breaker = CircuitBreaker(failure_threshold=0.5, recovery_timeout=1)
+
+        # Open the circuit
+        for _ in range(4):
+            breaker.record_success()
+        for _ in range(6):
+            breaker.record_failure()
+        assert breaker.state == "open"
+
+        # Enter half-open after recovery timeout
+        time.sleep(1.1)
+        assert breaker.is_open() is False
+        assert breaker.state == "half_open"
+
+        # A single failure during probation trips the circuit back open
+        breaker.record_failure()
+        assert breaker.state == "open"
+        assert breaker.is_open() is True
+
+    def test_half_open_failure_not_forgotten_by_successes(self):
+        """Test that a half-open failure is not forgotten by later successes."""
+        breaker = CircuitBreaker(failure_threshold=0.5, recovery_timeout=1)
+
+        # Open the circuit
+        for _ in range(4):
+            breaker.record_success()
+        for _ in range(6):
+            breaker.record_failure()
+        assert breaker.state == "open"
+
+        # Enter half-open after recovery timeout
+        time.sleep(1.1)
+        breaker.is_open()
+        assert breaker.state == "half_open"
+
+        # One failure followed by enough successes to close a healthy circuit
+        breaker.record_failure()
+        for _ in range(3):
+            breaker.record_success()
+
+        # The failure must keep the circuit open
+        assert breaker.state == "open"
+
     def test_get_state(self):
         """Test get_state method."""
         breaker = CircuitBreaker()


### PR DESCRIPTION
## What does this PR address?

`CircuitBreaker.record_failure` ignored the `half_open` state. During the recovery probation the minimum-sample gate (`total >= 10`) and the success counter interact so that:

1. a failure in half-open neither re-opens the circuit nor does anything else — the breaker keeps passing traffic while staying in `half_open`, and
2. a half-open failure followed by three successes **closes** the circuit with the failure completely forgotten — the standard breaker semantic is "any failure during probation trips the breaker back open".

Concretely, after `open → half_open`, one failed request + three successes reported `closed`. In the executor (`concurrent.py`) this means a recovered-but-still-failing upstream is silently treated as healthy.

## Fix

At the top of `record_failure`, a `half_open` state now trips the breaker back to `open` with fresh counters (mirroring the counter reset already performed when entering half-open), before any sample-size logic runs.

## Test

Two regression tests in `tests/unit/executor/test_circuit_breaker.py`:

- `test_half_open_failure_reopens_circuit`: open → half-open → one failure → asserts `state == "open"` and `is_open() is True` (fails on main, which stays `half_open`).
- `test_half_open_failure_not_forgotten_by_successes`: open → half-open → one failure + three successes → asserts `state == "open"` (fails on main, which closes).

Local: `tests/unit/executor/test_circuit_breaker.py` 16 passed (14 pre-existing + 2 new); black 26.3.1 and flake8 7.3.0 clean on the changed module.

## Diff Scope

2 files, +54/-0 (agentic_security/executor/circuit_breaker.py, tests/unit/executor/test_circuit_breaker.py).