### PR TITLE
fix(executor): compute p95 latency as a real 95th percentile

### DIFF
--- a/agentic_security/executor/concurrent.py
+++ b/agentic_security/executor/concurrent.py
@@ -1,6 +1,7 @@
 """Concurrent executor with rate limiting and circuit breaking."""
 
 import asyncio
+import math
 import time
 from typing import Any
 
@@ -60,12 +61,11 @@ class ExecutorMetrics:
         # Calculate p95 latency
         if self.latencies:
             sorted_latencies = sorted(self.latencies)
-            p95_index = int(len(sorted_latencies) * 0.95)
-            p95_latency_ms = (
-                sorted_latencies[p95_index] * 1000
-                if p95_index < len(sorted_latencies)
-                else 0.0
-            )
+            # ceil(n * 0.95) - 1 picks the 95th-percentile element; the
+            # previous int(n * 0.95) collapsed to the last index (the max)
+            # for any batch of 20 or fewer requests.
+            p95_index = max(0, math.ceil(len(sorted_latencies) * 0.95) - 1)
+            p95_latency_ms = sorted_latencies[p95_index] * 1000
         else:
             p95_latency_ms = 0.0
 

--- a/tests/unit/executor/test_concurrent.py
+++ b/tests/unit/executor/test_concurrent.py
@@ -83,6 +83,19 @@ class TestExecutorMetrics:
         assert stats["p95_latency_ms"] >= 90.0
         assert stats["p95_latency_ms"] <= 100.0
 
+    def test_get_stats_p95_latency_small_batch(self):
+        """Test that p95 is the 95th percentile, not the maximum, for small batches."""
+        metrics = ExecutorMetrics()
+
+        # 20 requests with latencies 0ms..19ms
+        for i in range(20):
+            metrics.record_success(i * 0.001)
+
+        stats = metrics.get_stats()
+
+        # The 95th percentile of 20 samples is the 19th (18ms), not the max (19ms)
+        assert stats["p95_latency_ms"] == pytest.approx(18.0)
+
 
 class TestConcurrentExecutor:
     """Test ConcurrentExecutor functionality."""


### PR DESCRIPTION
## What does this PR address?

`ExecutorMetrics.get_stats` picked the p95 latency element with `int(n * 0.95)`. For any batch of 20 or fewer requests that index collapses to `n - 1` — the **maximum** — so the "p95" metric reported the worst-case latency for typical scan batches. `int(n * 0.95)` only approximates a real percentile for larger sample sizes (and still lands ~1% high).

For a batch of 20 with latencies 0..19ms, the stats endpoint reported p95 = 19ms (the max) instead of 18ms (the actual 95th percentile).

## Fix

Use the standard nearest-rank index `max(0, ceil(n * 0.95) - 1)` in `agentic_security/executor/concurrent.py`. The existing 100-sample behavior stays within the same bounds (94ms instead of 95ms), and small batches now report the correct percentile.

## Test

Added `test_get_stats_p95_latency_small_batch` in tests/unit/executor/test_concurrent.py: 20 samples 0..19ms → asserts p95 == 18ms (fails on main with 19.0). The pre-existing `test_get_stats_p95_latency` (100 samples) still passes.

Local: tests/unit/executor/test_concurrent.py 14 passed; flake8 7.3.0 + black 26.3.1 clean on the changed module.

## Diff Scope

2 files, +19/-6 (agentic_security/executor/concurrent.py, tests/unit/executor/test_concurrent.py).