### PR TITLE
fix(verify): move spec parsing inside the try block so relative URLs 400, not 500

### DIFF
--- a/agentic_security/routes/scan.py
+++ b/agentic_security/routes/scan.py
@@ -30,8 +30,8 @@ async def verify(
     info: LLMInfo, secrets: InMemorySecrets = Depends(get_in_memory_secrets)
 ) -> dict[str, int | str | float]:
     logger.info("verify: checking LLM spec connectivity")
-    spec = LLMSpec.from_string(info.spec)
     try:
+        spec = LLMSpec.from_string(info.spec)
         r = await spec.verify()
     except InvalidHTTPSpecError as e:
         logger.warning("verify: invalid HTTP spec: %s", e)

--- a/tests/integration/routes/test_scan.py
+++ b/tests/integration/routes/test_scan.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+
+from agentic_security.app import app
+
+client = TestClient(app)
+
+
+def test_verify_relative_url_returns_400_not_500():
+    """A relative-URL spec should fail parsing with a clean 400, not an
+    uncaught 500. See https://github.com/msoedov/agentic_security/issues/149.
+    """
+    spec = "POST /chat HTTP/2\nHost: promptairlines.com\nContent-Type: application/json\n\n{}"
+    response = client.post("/verify", json={"spec": spec})
+    assert response.status_code == 400
+    assert "Failed to parse HTTP spec" in response.json()["detail"]


### PR DESCRIPTION
`LLMSpec.from_string(info.spec)` on line 32 of `routes/scan.py` sits one line above the `try:` block that already catches `InvalidHTTPSpecError` and turns it into a 400. `from_string` re-raises every parse failure as `InvalidHTTPSpecError` (a relative URL, an empty spec, a malformed header line), so any of those inputs propagates straight past the existing handler and out of the endpoint. With no app-level exception handler in the repo, FastAPI's default handler turns that into a raw 500 instead of the 400 the route is clearly meant to return.

Fix: move the `from_string` call inside the try block so it shares the handler that already exists one line below it. One-line move, no new branches.

Verification:
- Added `tests/integration/routes/test_scan.py`, posting the relative-URL spec from the issue to `/verify`. Fails on main (500, same traceback as the issue), passes on the branch (400 with the parse-failure detail).
- Full suite via `poetry install && poetry run pytest .` (Python 3.14, matching CI): 442 passed, 4 skipped, 41 deselected.
- `black`, `flake8`, `pyupgrade --py314-plus` on the changed files: clean.
- Not checked: the HF/live-endpoint side of `verify()` (`spec.verify()` itself), since the bug and fix are entirely in the parsing path before that call.

Fixes #149
