### PR TITLE
fix(ui): mark integration verify failure on network errors

### DIFF
--- a/agentic_security/static/main.js
+++ b/agentic_security/static/main.js
@@ -245,7 +245,7 @@ var app = new Vue({
                     this.integrationVerified = true;
                 }
             } catch (error) {
-                this.updateStatusDot(true);
+                this.updateStatusDot(false);
                 this.errorMsg = 'Server unreachable';
                 this.showToast('Network error', 'error');
             }


### PR DESCRIPTION
## Summary
Set status dot to failed when verifyIntegration fetch throws instead of incorrectly showing success.

Fixes #173

## Test plan
- [x] UI error path sets updateStatusDot(false)