### PR TITLE
fix(ui): mark integration verify failure on network errors

### DIFF
--- a/agentic_security/static/main.js
+++ b/agentic_security/static/main.js
@@ -245,7 +245,7 @@ var app = new Vue({
                     this.integrationVerified = true;
                 }
             } catch (error) {
-                this.updateStatusDot(true);
+                this.updateStatusDot(false);
                 this.errorMsg = 'Server unreachable';
                 this.showToast('Network error', 'error');
             }


### PR DESCRIPTION
Fixes #173

## Summary
Mark integration verify as failed in the UI when network errors occur.

## Test plan
- [x] Frontend handles verify API failures