### PR TITLE
docs: add CLI reference and correct configuration filename

### DIFF
--- a/agentic_security/lib.py
+++ b/agentic_security/lib.py
@@ -202,7 +202,7 @@ class SecurityScanner(SettingsMixin):
     def entrypoint(self):
         # Load configuration from the default path
         if not self.has_local_config():
-            print("`agesec.toml` configuration file not found.")
+            print("`agentic_security.toml` configuration file not found.")
             exit(1)
 
         self.load_config(self.default_path)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,67 @@
+# Command-line interface
+
+The `agentic_security` command provides four commands: start the web server,
+create a configuration file, list the available checks, and run a configured
+scan.
+
+```bash
+agentic_security --help
+```
+
+## Start the server
+
+Run the web application on the local machine:
+
+```bash
+agentic_security server --host=127.0.0.1 --port=8718
+```
+
+`s` is a short alias for `server`. Running `agentic_security` without a
+subcommand shows the available command help.
+
+## Create a scan configuration
+
+Create `agentic_security.toml` in the current directory:
+
+```bash
+agentic_security init
+```
+
+Set a different target host or port in the generated HTTP specification:
+
+```bash
+agentic_security init --host=127.0.0.1 --port=8718
+```
+
+`i` is a short alias for `init`. The command overwrites an existing
+`agentic_security.toml`, so save any custom changes first.
+
+## List available checks
+
+Inspect the built-in dataset registry before selecting modules for a scan:
+
+```bash
+agentic_security ls
+```
+
+## Run a configured scan
+
+After reviewing `agentic_security.toml` and replacing the example `llmSpec`
+with the target endpoint, run:
+
+```bash
+agentic_security ci
+```
+
+The command uses `agentic_security.toml` from the current directory. It exits
+without scanning if the file is missing. To include your own prompts, follow
+the [local datasets guide](datasets.md).
+
+## Python module form
+
+If the console script is not on your `PATH`, invoke the same CLI through
+Python:
+
+```bash
+python -m agentic_security ls
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@ This section provides information on configuring Agentic Security to suit your n
 
 ## Default Configuration
 
-The default configuration file is `agesec.toml`. It includes settings for:
+The default configuration file is `agentic_security.toml`. It includes settings for:
 
 - General settings
 - Module configurations
@@ -12,7 +12,7 @@ The default configuration file is `agesec.toml`. It includes settings for:
 
 ## Customizing Configuration
 
-1. Open the `agesec.toml` file in a text editor.
+1. Open the `agentic_security.toml` file in a text editor.
 1. Modify the settings as needed. For example, to change the port:
    ```toml
    [modules.AgenticBackend.opts]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,7 +7,7 @@ Welcome to Agentic Security! This guide will help you get started with using the
 1. Ensure you have completed the [installation](installation.md) steps.
 1. Run the following command to start the application:
    ```bash
-   agentic_security
+agentic_security server
    ```
 1. Access the application at `http://localhost:8718`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ pip install agentic_security
 After installation, you can start the application using the following command:
 
 ```shell
-agentic_security
+agentic_security server
 ```
 
 This will initialize the server and prepare it for use.
@@ -42,7 +42,7 @@ Initialize the configuration for CI checks:
 agentic_security init
 ```
 
-This will generate a default configuration file named `agesec.toml`.
+This will generate a default configuration file named `agentic_security.toml`.
 
 ## Additional Commands
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - Installation: installation.md
     - Getting Started: getting_started.md
     - Configuration: configuration.md
+    - CLI reference: cli.md
   - Advanced Topics:
     - Dataset Extension: datasets.md
     - External Modules: external_module.md


### PR DESCRIPTION
## Description

This PR adds a CLI reference to the documentation and corrects the configuration filename referenced in the docs.

### Changes

* Added documentation for the CLI commands and usage.
* Corrected the configuration filename to match the actual project file.
