### PR TITLE
feat: add Atlas Cloud LLM provider

### DIFF
--- a/agentic_security/llm_providers/__init__.py
+++ b/agentic_security/llm_providers/__init__.py
@@ -7,6 +7,7 @@ from agentic_security.llm_providers.base import (
 )
 from agentic_security.llm_providers.openai_provider import OpenAIProvider
 from agentic_security.llm_providers.anthropic_provider import AnthropicProvider
+from agentic_security.llm_providers.atlascloud_provider import AtlasCloudProvider
 from agentic_security.llm_providers.litellm_provider import LiteLLMProvider
 from agentic_security.llm_providers.factory import create_provider, get_provider_class
 
@@ -18,6 +19,7 @@ __all__ = [
     "LLMRateLimitError",
     "OpenAIProvider",
     "AnthropicProvider",
+    "AtlasCloudProvider",
     "LiteLLMProvider",
     "create_provider",
     "get_provider_class",

--- a/agentic_security/llm_providers/atlascloud_provider.py
+++ b/agentic_security/llm_providers/atlascloud_provider.py
@@ -1,0 +1,31 @@
+"""Atlas Cloud LLM provider implementation."""
+
+from typing import Any
+
+from agentic_security.llm_providers.openai_provider import OpenAIProvider
+
+
+class AtlasCloudProvider(OpenAIProvider):
+    """Atlas Cloud provider using its OpenAI-compatible chat API."""
+
+    DEFAULT_MODEL = "qwen/qwen3.5-397b-a17b"
+    DEFAULT_BASE_URL = "https://api.atlascloud.ai/v1"
+    API_KEY_ENV = "ATLASCLOUD_API_KEY"
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        api_key: str | None = None,
+        base_url: str = DEFAULT_BASE_URL,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            **kwargs,
+        )
+
+    @classmethod
+    def get_supported_models(cls) -> list[str]:
+        return [cls.DEFAULT_MODEL]

--- a/agentic_security/llm_providers/factory.py
+++ b/agentic_security/llm_providers/factory.py
@@ -14,10 +14,12 @@ def _ensure_registered() -> None:
         return
     from agentic_security.llm_providers.openai_provider import OpenAIProvider
     from agentic_security.llm_providers.anthropic_provider import AnthropicProvider
+    from agentic_security.llm_providers.atlascloud_provider import AtlasCloudProvider
     from agentic_security.llm_providers.litellm_provider import LiteLLMProvider
 
     _PROVIDERS["openai"] = OpenAIProvider
     _PROVIDERS["anthropic"] = AnthropicProvider
+    _PROVIDERS["atlascloud"] = AtlasCloudProvider
     _PROVIDERS["litellm"] = LiteLLMProvider
 
 

--- a/tests/unit/llm_providers/test_atlascloud_provider.py
+++ b/tests/unit/llm_providers/test_atlascloud_provider.py
@@ -1,0 +1,38 @@
+"""Tests for the Atlas Cloud provider."""
+
+import pytest
+from inline_snapshot import snapshot
+
+from agentic_security.llm_providers.atlascloud_provider import AtlasCloudProvider
+from agentic_security.llm_providers.base import LLMProviderError
+
+
+class TestAtlasCloudProviderInit:
+    def test_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+        with pytest.raises(LLMProviderError) as exc:
+            AtlasCloudProvider()
+        assert "ATLASCLOUD_API_KEY" in str(exc.value)
+
+    def test_uses_atlas_defaults(self, monkeypatch):
+        monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+        provider = AtlasCloudProvider()
+        assert provider.api_key == snapshot("test-key")
+        assert provider.model == snapshot("qwen/qwen3.5-397b-a17b")
+        assert provider.base_url == snapshot("https://api.atlascloud.ai/v1")
+
+    def test_accepts_overrides(self, monkeypatch):
+        monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+        provider = AtlasCloudProvider(
+            model="custom/model",
+            api_key="direct-key",
+            base_url="https://example.com/v1",
+        )
+        assert provider.model == snapshot("custom/model")
+        assert provider.api_key == snapshot("direct-key")
+        assert provider.base_url == snapshot("https://example.com/v1")
+
+    def test_supported_models_includes_default(self, monkeypatch):
+        monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+        provider = AtlasCloudProvider()
+        assert provider.get_supported_models() == snapshot(["qwen/qwen3.5-397b-a17b"])

--- a/tests/unit/llm_providers/test_factory.py
+++ b/tests/unit/llm_providers/test_factory.py
@@ -21,6 +21,7 @@ class TestListProviders:
         providers = list_providers()
         assert "openai" in providers
         assert "anthropic" in providers
+        assert "atlascloud" in providers
 
     def test_returns_sorted_list(self):
         providers = list_providers()
@@ -39,6 +40,14 @@ class TestGetProviderClass:
 
         cls = get_provider_class("anthropic")
         assert cls is AnthropicProvider
+
+    def test_get_atlascloud(self):
+        from agentic_security.llm_providers.atlascloud_provider import (
+            AtlasCloudProvider,
+        )
+
+        cls = get_provider_class("atlascloud")
+        assert cls is AtlasCloudProvider
 
     def test_case_insensitive(self):
         cls1 = get_provider_class("OpenAI")
@@ -97,6 +106,12 @@ class TestCreateProvider:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         provider = create_provider("anthropic", model="claude-3-5-sonnet-latest")
         assert provider.model == snapshot("claude-3-5-sonnet-latest")
+
+    def test_create_atlascloud_with_default_model(self, monkeypatch):
+        monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+        provider = create_provider("atlascloud")
+        assert provider.model == snapshot("qwen/qwen3.5-397b-a17b")
+        assert provider.base_url == snapshot("https://api.atlascloud.ai/v1")
 
     def test_create_with_api_key(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)


### PR DESCRIPTION
## Summary

- add an opt-in Atlas Cloud provider using the existing OpenAI-compatible implementation
- register and export `atlascloud` with a verified default model and endpoint
- cover environment, override, supported-model, and factory behavior

## Testing

- `pytest tests/unit/llm_providers/test_atlascloud_provider.py tests/unit/llm_providers/test_factory.py tests/unit/llm_providers/test_openai_provider.py` (37 passed)
- `pre-commit run --files ...` (all hooks passed)
- live Atlas Cloud chat-completions smoke test returned the expected response