### PR TITLE
fix(refusal_classifier): quote self-referential annotation to fix import NameError

### DIFF
--- a/agentic_security/refusal_classifier/hybrid_classifier.py
+++ b/agentic_security/refusal_classifier/hybrid_classifier.py
@@ -86,7 +86,7 @@ class HybridRefusalClassifier:
         detector: RefusalDetector,
         weight: float = 1.0,
         name: str | None = None,
-    ) -> HybridRefusalClassifier:
+    ) -> "HybridRefusalClassifier":
         """Add a detection method with specified weight.
 
         Args:


### PR DESCRIPTION
### Problem

`agentic_security/refusal_classifier/hybrid_classifier.py` raises `NameError` **at import time**, which breaks the entire `HybridRefusalClassifier` module (and any test or code that imports it).

The `add_detector` method is defined *inside* `class HybridRefusalClassifier` with a return annotation that refers to the class itself:

```python
class HybridRefusalClassifier:
    def add_detector(
        self,
        detector: RefusalDetector,
        weight: float = 1.0,
        name: str | None = None,
    ) -> HybridRefusalClassifier:   # <-- evaluated eagerly during class-body execution
```

The module does **not** use `from __future__ import annotations`, so this return annotation is evaluated eagerly while the class body is still executing — at which point the name `HybridRefusalClassifier` is not yet bound. Importing the module fails:

```
$ python -c "import agentic_security.refusal_classifier.hybrid_classifier"
NameError: name 'HybridRefusalClassifier' is not defined
```

Because `tests/unit/refusal_classifier/test_hybrid_classifier.py` imports the module at the top level, that whole test file currently fails to collect.

The module-level factory `create_hybrid_classifier(...) -> HybridRefusalClassifier` is fine — it runs *after* the class is defined; only the in-class self-reference is affected.

### Fix

Quote the self-referential annotation so it becomes a forward reference (standard PEP 484 pattern), matching how self-references are normally written without `from __future__ import annotations`:

```python
    ) -> "HybridRefusalClassifier":
```

One-line change, no behavior change.

### Verification

Before: `import agentic_security.refusal_classifier.hybrid_classifier` → `NameError`.
After: the module imports cleanly and `HybridRefusalClassifier()` instantiates, so `tests/unit/refusal_classifier/test_hybrid_classifier.py` can be collected again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
